### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/ujidoko39/ce059813-6847-4875-a794-b0559cbcf004/87d7b65f-614d-40fc-a0c9-185dfbd2999f/_apis/work/boardbadge/bfb779a8-4bca-4dcc-aaa1-b77fe10ff5b5)](https://dev.azure.com/ujidoko39/ce059813-6847-4875-a794-b0559cbcf004/_boards/board/t/87d7b65f-614d-40fc-a0c9-185dfbd2999f/Microsoft.RequirementCategory)
 ## Your GitHub Learning Lab Repository for Communicating Using Markdown
 
 Welcome to **your** repository for your GitHub Learning Lab course. This repository will be used during the different activities that I will be guiding you through.


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/ujidoko39/ce059813-6847-4875-a794-b0559cbcf004/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.